### PR TITLE
Keryan

### DIFF
--- a/wsidle
+++ b/wsidle
@@ -118,10 +118,11 @@ function kill_unauthorized_sessions(array $user,
     return $has_killed_user;
 }
 
-function get_room(string $computer_name)
+function get_room(string $computer_name,
+		  string $nfs_server)
 {
-    $ret = json_decode(SendData($nfs_server, ["command" => "getcomputerroom", "name" => $packet["name"]]));
-    if ($ret["result"] == "ok")
+    $ret = json_decode(SendData($nfs_server, ["command" => "getcomputerroom", "name" => $computer_name]));
+    if (isset($ret["result"]) && $ret["result"] == "ok")
 	return $ret["content"];
     return "";
 }
@@ -151,15 +152,20 @@ $packet["type"] = (substr(shell_exec("uname -m"), 0, 6) == "x86_64") ? 0 : 3; //
 $EXAM = false;
 
 // Récupération de la room
-$room_info = ["name" => get_room($packet["name"]), "exam_only" => false];
+$room_info = ["name" => get_room($packet["name"], $nfs_server), "exam_only" => false];
 
 do
 {
     // Récupération des élèves en examens
-    $exam_stats = json_decode(SendData($nfs_server, ["command" => "getexamstudents"])["content"]);
+    $exam_stats = SendData($nfs_server, ["command" => "getexamstudents"]);
+    if (!isset($exam_stats))
+	continue;
+    $exam_stats = json_decode($exam_stats["content"]);
     
     $packet["ip"] = refresh_ip();
     $packet["users"] = explode("\n", trim(shell_exec("who | cut -d ' ' -f 1,2 | tr ' ' ';' | sort | uniq")));
+    if (!isset($packet["users"]))
+	continue;
     
     // On parcoure les utilisateurs afin de trouver ceux en mode exam
     foreach ($packet["users"] as $usr)

--- a/wsidle
+++ b/wsidle
@@ -151,6 +151,7 @@ $packet["type"] = (substr(shell_exec("uname -m"), 0, 6) == "x86_64") ? 0 : 3; //
 $EXAM = false;
 
 // Récupération de la room
+$computer_name = explode(".", $packet["name"])[0];
 $room_info = ["name" => get_room($packet["name"], $nfs_server), "exam_only" => false];
 
 do

--- a/wsidle
+++ b/wsidle
@@ -187,6 +187,15 @@ do
 		system("nft add chain inet filter output {type filter hook output ".
 		       "priority filter \; policy accept \; }");
 
+                system("nft add rule inet filter output meta squid $usr ".
+                       "ip daddr $ip_nfs tcp dport 111 accept");
+                system("nft add rule inet filter output meta squid $usr ".
+                       "ip daddr $ip_nfs tcp dport 2049 accept");
+                system("nft add rule inet filter output meta squid $usr ".
+                       "ip daddr $ip_nfs udp dport 111 accept");
+                system("nft add rule inet filter output meta squid $usr ".
+                       "ip daddr $ip_nfs udp dport 2049 accept");
+
 		system("nft add rule inet filter output meta squid $usr ".
 		       "ip daddr $ldap_server tcp dport 636 accept");
 		system("nft add rule inet filter output meta squid $usr ".

--- a/wsidle
+++ b/wsidle
@@ -58,11 +58,11 @@ function kill_unauthorized_sessions(array $user,
 				    string $nfs_server)
 {
     $has_killed_user = false;
-    $username = $user[0].$user[1];
+    $username = $user[0].".".$user[1];
 
     if (count($user) == 3 && substr($user[2], 0, 4) == "exam")
     {        
-        $exam_username = $username."exam";
+        $exam_username = $username.".exam";
         $user = shell_exec("id -u ".$exam_username);
 
         // On tue les sessions exam hors examens

--- a/wsidle
+++ b/wsidle
@@ -162,7 +162,12 @@ do
     $packet["users"] = explode("\n", trim(shell_exec("who | cut -d ' ' -f 1,2 | tr ' ' ';' | sort | uniq")));
     if (!isset($packet["users"]))
 	continue;
-    
+
+    if (in_array($room_info["name"], $exam_stats["users"]))
+	$room_info["exam_only"] = true;
+    else
+	$room_info["exam_only"] = false;
+
     // On parcoure les utilisateurs afin de trouver ceux en mode exam
     foreach ($packet["users"] as $usr)
     {

--- a/wsidle
+++ b/wsidle
@@ -190,6 +190,9 @@ do
         if (count($usr) == 3 && substr($usr[2], 0, 4) == "exam")
 	{	    
             $usr = shell_exec("id -u ".$usr[0].".".$usr[1].".exam");
+
+	    $usr = str_replace("\n", "", $usr);
+	    
             // On regarde si l'utilisateur est déjà dans la liste pour rejet
             $out = shell_exec("nft list ruleset | grep $usr");
             if (strlen($out) == 0 || str_contains($out, $usr) === false)

--- a/wsidle
+++ b/wsidle
@@ -17,7 +17,8 @@ function SendData($url, $data)
     $ship = hand_packet($data);
     $cmd = "cat $ship | ssh -o 'StrictHostKeyChecking no' infosphere_hand@$url -i /root/.ssh/ihk -p 4422 -tt infosphere_hand  2> /dev/null ; rm -f $ship";
     $ret = shell_exec($cmd);
-    return (json_decode($ret));
+    $ret = explode("\n", $ret);
+    return (json_decode(end($ret), true));
 }
 
 // On ne peut pas effectuer une écriture de taille supérieure à 4k, donc
@@ -102,14 +103,14 @@ function kill_unauthorized_sessions(array $user,
 				   "log" => "$exam_username has been killed because".
 					  " $exam_username is already connected somewhere else !"]);
 	}
-    } // On tue toutes les sessions non exam dans une salle d'examen
-    else if ($room["exam_only"])
+    } // On tue toutes les sessions non exam présentiel dans une salle d'examen
+    else if ($room["exam_only"] && strncmp($mode_connexion, "tty", 3) == 0)
     {
 	$has_killed_user = kill_user(shell_exec("id -u ".$username), $username, $user_pool);
 	SendData($nfs_server, ["command" => "addcustomlog",
 			       "log" => "$username has been killed because it's an exam only room"]);
     } // On tue les sessions non exam d'utilisateur en exam
-    else if (in_array($username, $exam_stats["users"]))
+    else if (isset($exam_stats["users"][$username]))
     {
         $has_killed_user = kill_user(shell_exec("id -u ".$username), $username, $user_pool);
 	SendData($nfs_server, ["command" => "addcustomlog",
@@ -123,7 +124,7 @@ function get_room(string $computer_name,
 {
     $ret = json_decode(SendData($nfs_server, ["command" => "getcomputerroom", "name" => $computer_name]));
     if (isset($ret["result"]) && $ret["result"] == "ok")
-	return $ret["content"];
+	return $ret["message"];
     return "";
 }
 
@@ -137,10 +138,7 @@ if ($argc < 5 || $argv[4] == "")
     $argv[4] = "192.168.200.1";
 
 $nfs_server = $argv[1];
-$ip_nfs = system("nslookup $nfs_server | grep 'Address:' | awk '{print $2}");
-$is_server = $argv[2];
 $ldap_server = $argv[3];
-$ip_ldap = system("nslookup $ldap_server | grep 'Address:' | awk '{print $2}");
 $net_server = $argv[4];
 
 // Initialisation du packet pour la commande log
@@ -187,23 +185,15 @@ do
             // Ce n'est pas le cas, on doit donc l'ajouter
 		system("nft add chain inet filter output {type filter hook output ".
 		       "priority filter \; policy accept \; }");
-		system("nft add rule inet filter output meta squid $usr ".
-		       "ip daddr $ip_nfs tcp dport 111 accept");
-		system("nft add rule inet filter output meta squid $usr ".
-		       "ip daddr $ip_nfs tcp dport 2049 accept");
-		system("nft add rule inet filter output meta squid $usr ".
-		       "ip daddr $ip_nfs udp dport 111 accept");
-		system("nft add rule inet filter output meta squid $usr ".
-		       "ip daddr $ip_nfs udp dport 2049 accept");
 
 		system("nft add rule inet filter output meta squid $usr ".
-		       "ip daddr $ip_ldap tcp dport 636 accept");
+		       "ip daddr $ldap_server tcp dport 636 accept");
 		system("nft add rule inet filter output meta squid $usr ".
-		       "ip daddr $ip_ldap tcp dport 3269 accept");
+		       "ip daddr $ldap_server tcp dport 3269 accept");
 		system("nft add rule inet filter output meta squid $usr ".
-		       "ip daddr $ip_ldap udp dport 636 accept");
+		       "ip daddr $ldap_server udp dport 636 accept");
 		system("nft add rule inet filter output meta squid $usr ".
-		       "ip daddr $ip_ldap udp dport 3269 accept");
+		       "ip daddr $ldap_server udp dport 3269 accept");
 
 		system("nft add rule inet filter output meta squid $usr ".
 		       "ip daddr $net_server tcp dport 1337 accept");

--- a/wsidle
+++ b/wsidle
@@ -194,30 +194,30 @@ do
 		system("nft add chain inet filter output {type filter hook output ".
 		       "priority filter \; policy accept \; }");
 
-                system("nft add rule inet filter output meta squid $usr ".
+                system("nft add rule inet filter output meta skuid $usr ".
                        "ip daddr $ip_nfs tcp dport 111 accept");
-                system("nft add rule inet filter output meta squid $usr ".
+                system("nft add rule inet filter output meta skuid $usr ".
                        "ip daddr $ip_nfs tcp dport 2049 accept");
-                system("nft add rule inet filter output meta squid $usr ".
+                system("nft add rule inet filter output meta skuid $usr ".
                        "ip daddr $ip_nfs udp dport 111 accept");
-                system("nft add rule inet filter output meta squid $usr ".
+                system("nft add rule inet filter output meta skuid $usr ".
                        "ip daddr $ip_nfs udp dport 2049 accept");
 
-		system("nft add rule inet filter output meta squid $usr ".
+		system("nft add rule inet filter output meta skuid $usr ".
 		       "ip daddr $ldap_server tcp dport 636 accept");
-		system("nft add rule inet filter output meta squid $usr ".
+		system("nft add rule inet filter output meta skuid $usr ".
 		       "ip daddr $ldap_server tcp dport 3269 accept");
-		system("nft add rule inet filter output meta squid $usr ".
+		system("nft add rule inet filter output meta skuid $usr ".
 		       "ip daddr $ldap_server udp dport 636 accept");
-		system("nft add rule inet filter output meta squid $usr ".
+		system("nft add rule inet filter output meta skuid $usr ".
 		       "ip daddr $ldap_server udp dport 3269 accept");
 
-		system("nft add rule inet filter output meta squid $usr ".
+		system("nft add rule inet filter output meta skuid $usr ".
 		       "ip daddr $net_server tcp dport 1337 accept");
-		system("nft add rule inet filter output meta squid $usr ".
+		system("nft add rule inet filter output meta skuid $usr ".
 		       "ip daddr $net_server tcp dport 1337 accept");
             
-            if (!(system("nft add rule filter output meta squid $usr reject") === 0))
+            if (!(system("nft add rule filter output meta skuid $usr reject") === 0))
                 system("pkill -u $usr");
             }
         }

--- a/wsidle
+++ b/wsidle
@@ -217,7 +217,7 @@ do
 		system("nft add rule inet filter output meta skuid $usr ".
 		       "ip daddr $net_server tcp dport 1337 accept");
             
-            if (!(system("nft add rule filter output meta skuid $usr reject") === 0))
+            if (!(system("nft add rule inet filter output meta skuid $usr reject") === 0))
                 system("pkill -u $usr");
             }
         }

--- a/wsidle
+++ b/wsidle
@@ -152,7 +152,7 @@ $EXAM = false;
 
 // Récupération de la room
 $computer_name = explode(".", $packet["name"])[0];
-$room_info = ["name" => get_room($packet["name"], $nfs_server), "exam_only" => false];
+$room_info = ["name" => get_room($computer_name, $nfs_server), "exam_only" => false];
 
 do
 {

--- a/wsidle
+++ b/wsidle
@@ -122,7 +122,7 @@ function kill_unauthorized_sessions(array $user,
 function get_room(string $computer_name,
 		  string $nfs_server)
 {
-    $ret = json_decode(SendData($nfs_server, ["command" => "getcomputerroom", "name" => $computer_name]));
+    $ret = SendData($nfs_server, ["command" => "getcomputerroom", "name" => $computer_name]);
     if (isset($ret["result"]) && $ret["result"] == "ok")
 	return $ret["message"];
     return "";
@@ -156,9 +156,6 @@ do
 {
     // Récupération des élèves en examens
     $exam_stats = SendData($nfs_server, ["command" => "getexamstudents"]);
-    if (!isset($exam_stats))
-	continue;
-    $exam_stats = json_decode($exam_stats["content"]);
     
     $packet["ip"] = refresh_ip();
     $packet["users"] = explode("\n", trim(shell_exec("who | cut -d ' ' -f 1,2 | tr ' ' ';' | sort | uniq")));

--- a/wsidle
+++ b/wsidle
@@ -166,7 +166,11 @@ do
     foreach ($packet["users"] as $usr)
     {
         $usr = explode(".", $usr);
-	$mode_connexion = explode(";", end($user))[1];
+	if (count($usr) == 1)
+	    continue;
+	$usr_part = explode(";", end($usr));
+	$usr[count($usr) - 1] = $usr_part[0];
+	$mode_connexion = $user_part[1];
         
         if (kill_unauthorized_sessions($usr, $exam_stats, $packet["users"], $mode_connexion, $room_info))
             continue;

--- a/wsidle
+++ b/wsidle
@@ -113,7 +113,8 @@ function kill_unauthorized_sessions(array $user,
     {
         $has_killed_user = kill_user(shell_exec("id -u ".$username), $username, $user_pool);
 	SendData($nfs_server, ["command" => "addcustomlog",
-			     "log" => "$username has been killed because $username must be in exam"]);
+			       "log" => "$username has been killed because $username must be in exam"]);
+    }
     return $has_killed_user;
 }
 

--- a/wsidle
+++ b/wsidle
@@ -185,7 +185,7 @@ do
 	    // Leur compte est forcement prenom.nom.exam
         if (count($usr) == 3 && substr($usr[2], 0, 4) == "exam")
 	{	    
-            $usr = shell_exec("id -u ".$usr[0].$usr[1]."exam");
+            $usr = shell_exec("id -u ".$usr[0].".".$usr[1].".exam");
             // On regarde si l'utilisateur est déjà dans la liste pour rejet
             $out = shell_exec("nft list ruleset | grep $usr");
             if (strlen($out) == 0 || str_contains($out, $usr) === false)

--- a/wsidle
+++ b/wsidle
@@ -43,9 +43,22 @@ function refresh_ip()
     return ($out);
 }
 
-function kill_user(int $target_id, string $target_name, array $kill_area)
+function kill_user(int $target_id,
+		   string $target_name,
+		   array $kill_area,
+		   array $killer_manager)
 {
-    system("pkill -u $target_id");
+    if (!isset($killer_manager["killed_user"][$target_name]) ||
+	$killer_manager["killed_user"][$target_name] != ($killer_manager["time"] - 1))
+    {
+	system("pkill -u $target_id");
+	$killer_manager["killed_user"][$target_name] = $killer_manager["time"];
+    }
+    else
+    {
+	system("pkill -u -9 $target_id");
+	$killer_manager["killed_user"][$target_name] = $killer_manager["time"];
+    }
     unset($kill_area[$target_name]);
     return(true);
 }
@@ -55,7 +68,8 @@ function kill_unauthorized_sessions(array $user,
 				    array $user_pool,
 				    string $mode_connexion,
 				    array $room,
-				    string $nfs_server)
+				    string $nfs_server,
+				    array $killer_manager)
 {
     $has_killed_user = false;
     $username = $user[0].".".$user[1];
@@ -157,6 +171,7 @@ $EXAM = false;
 // Récupération de la room
 $computer_name = explode(".", $packet["name"])[0];
 $room_info = ["name" => get_room($computer_name, $nfs_server), "exam_only" => false];
+$killer_manager = ["time" => 0, "killed_user" => []];
 
 do
 {
@@ -183,7 +198,7 @@ do
 	$usr[count($usr) - 1] = $usr_part[0];
 	$mode_connexion = $usr_part[1];
         
-        if (kill_unauthorized_sessions($usr, $exam_stats, $packet["users"], $mode_connexion, $room_info, $nfs_server))
+        if (kill_unauthorized_sessions($usr, $exam_stats, $packet["users"], $mode_connexion, $room_info, $nfs_server, $killer_manager))
             continue;
 
 	    // Leur compte est forcement prenom.nom.exam
@@ -233,6 +248,9 @@ do
         SendData($nfs_server, $packet);
         
     }
+    $killer_manager["time"] += 1;
+    if ($killer_manager["time"] == 1000000)
+	$killer_manager["time"] = 0;
     system("sleep 5.0");
 }
 while (1);

--- a/wsidle
+++ b/wsidle
@@ -131,7 +131,7 @@ function get_room(string $computer_name,
 if ($argc < 2 || $argv[1] == "")
     $argv[1] = "nfs.efrits.fr";
 if ($argc < 3 || $argv[2] == "")
-    $argv[2] = "intra.efrits.fr";
+    $argv[2] = "192.168.200.1";
 if ($argc < 4 || $argv[3] == "")
     $argv[3] = "192.168.200.1";
 if ($argc < 5 || $argv[4] == "")

--- a/wsidle
+++ b/wsidle
@@ -168,7 +168,7 @@ do
     if (!isset($packet["users"]))
 	continue;
 
-    if (in_array($room_info["name"], $exam_stats["users"]))
+    if (isset($exam_stats["users"]) && in_array($room_info["name"], $exam_stats["users"]))
 	$room_info["exam_only"] = true;
     else
 	$room_info["exam_only"] = false;

--- a/wsidle
+++ b/wsidle
@@ -84,14 +84,14 @@ function kill_unauthorized_sessions(array $user,
 	
 	if (!isset($exam_stats["users"][$username]))
 	    {
-		$has_killed_user = kill_user($user, $exam_username, $user_pool);
+		$has_killed_user = kill_user($user, $exam_username, $user_pool, $killer_manager);
 		SendData($nfs_server, ["command" => "addcustomlog",
 				       "log" => "$exam_username has been killed, because ".
 					      "there is no exam for now !"]);
 	    }
 	else if ($exam_stats["users"][$username] != $room["name"])
 	    {
-		$has_killed_user = kill_user($user, $exam_username, $user_pool);
+		$has_killed_user = kill_user($user, $exam_username, $user_pool, $killer_manager);
 		SendData($nfs_server, ["command" => "addcustomlog",
 				       "log" => "$exam_username has been killed, because ".
 					      "$exam_username is not in the right room"]);
@@ -100,7 +100,7 @@ function kill_unauthorized_sessions(array $user,
         // On tue les sessions exam qui ne sont pas en présentiels
         if (strncmp($mode_connexion, "tty", 3) != 0)
 	    {
-		$has_killed_user = kill_user($user, $exam_username, $user_pool);
+		$has_killed_user = kill_user($user, $exam_username, $user_pool, $killer_manager);
 		SendData($nfs_server, ["command" => "addcustomlog",
 				       "log" => "$exam_username has been killed, because ".
 					      "exam cannot be in remote session"]);
@@ -112,7 +112,7 @@ function kill_unauthorized_sessions(array $user,
         if (isset($exam_stats["connected"][$exam_username])
 	    && $exam_stats["connected"][$exam_username] != refresh_ip())
 	{
-            $has_killed_user = kill_user($user, $exam_username, $user_pool);
+            $has_killed_user = kill_user($user, $exam_username, $user_pool, $killer_manager);
 	    SendData($nfs_server, ["command" => "addcustomlog",
 				   "log" => "$exam_username has been killed because".
 					  " $exam_username is already connected somewhere else !"]);
@@ -120,13 +120,13 @@ function kill_unauthorized_sessions(array $user,
     } // On tue toutes les sessions non exam présentiel dans une salle d'examen
     else if ($room["exam_only"] && strncmp($mode_connexion, "tty", 3) == 0)
     {
-	$has_killed_user = kill_user(shell_exec("id -u ".$username), $username, $user_pool);
+	$has_killed_user = kill_user(shell_exec("id -u ".$username), $username, $user_pool, $killer_manager);
 	SendData($nfs_server, ["command" => "addcustomlog",
 			       "log" => "$username has been killed because it's an exam only room"]);
     } // On tue les sessions non exam d'utilisateur en exam
     else if (isset($exam_stats["users"][$username]))
     {
-        $has_killed_user = kill_user(shell_exec("id -u ".$username), $username, $user_pool);
+        $has_killed_user = kill_user(shell_exec("id -u ".$username), $username, $user_pool, $killer_manager);
 	SendData($nfs_server, ["command" => "addcustomlog",
 			       "log" => "$username has been killed because $username must be in exam"]);
     }

--- a/wsidle
+++ b/wsidle
@@ -42,6 +42,45 @@ function refresh_ip()
     return ($out);
 }
 
+function kill_user(int $target_id, string $target_name, array $kill_area)
+{
+    system("pkill -u $target_id");
+    unset($kill_area[$target_name]);
+    return(true);
+}
+
+function kill_unauthorized_sessions(array $user, array $exam_stats, array $user_pool)
+{
+    $has_killed_user = false;
+    $username = $user[0].$user[1];
+
+    if (count($user) == 3 && substr($user[2], 0, 4) == "exam")
+    {
+        $mode_connexion = explode(";", $user[2])[1];
+        
+        $exam_username = $username."exam";
+        $user = shell_exec("id -u ".$exam_username);
+
+        // On tue les sessions exam hors examens
+        // Par contre ça va shutdown les sessions juste après le ramassage de Infosphere_hand mdr
+        if (!in_array($username, $exam_stats["users"]))
+            $has_killed_user = kill_user($user, $exam_username, $user_pool);
+
+        // On tue les sessions exam qui ne sont pas en présentiels
+        if (strncmp($mode_connexion, "tty", 3) != 0)
+            $has_killed_user = kill_user($user, $exam_username, $user_pool);
+
+        // On tue les sessions exam en double, 
+        // Normalement il y le Xauthority qui n'est pas en lien symbolique
+        // On regarde s'il l'utilisateur est déjà connecté et s'il ne l'est pas ailleurs
+        if (in_array($exam_username, $exam_stats["connected"]) && $exam_stats["connected"][$exam_username] != refresh_ip())
+            $has_killed_user = kill_user($user, $exam_username, $user_pool);
+    } // On tue les sessions non exam d'utilisateur en exam
+    else if (in_array($username, $exam_stats["users"]))
+        $has_killed_user = kill_user(shell_exec("id -u ".$username), $username, $user_pool);
+    return $has_killed_user;
+}
+
 if ($argc < 2 || $argv[1] == "")
     $argv[1] = "nfs.efrits.fr";
 if ($argc < 3 || $argv[2] == "")
@@ -52,10 +91,13 @@ if ($argc < 5 || $argv[4] == "")
     $argv[4] = "192.168.200.1";
 
 $nfs_server = $argv[1];
+$ip_nfs = system("nslookup $nfs_server | grep 'Address:' | awk '{print $2}");
 $is_server = $argv[2];
 $ldap_server = $argv[3];
+$ip_ldap = system("nslookup $ldap_server | grep 'Address:' | awk '{print $2}");
 $net_server = $argv[4];
-	
+
+// Initialisation du packet pour la commande log
 $packet["mac"] = trim(file_get_contents("/sys/class/net/eno1/address"));
 $packet["name"] = trim(file_get_contents("/proc/sys/kernel/hostname"));
 $packet["command"] = "log";
@@ -63,57 +105,56 @@ $packet["type"] = (substr(shell_exec("uname -m"), 0, 6) == "x86_64") ? 0 : 3; //
 
 $EXAM = false;
 
+
+
 do
 {
+    // Récupération des élèves en examens
+    $exam_stats = json_decode(SendData($nfs_server, ["command" => "getexamstudents"])["content"]);
     $packet["ip"] = refresh_ip();
     $packet["users"] = explode("\n", trim(shell_exec("who | cut -d ' ' -f 1,2 | tr ' ' ';' | sort | uniq")));
-    
-    // On vérifie si la chaine EXAM existe
-    $EXAM = shell_exec("iptables -L EXAM 2> /dev/null");
-    if ($EXAM == "")
-    {
-	system("iptables -N EXAM");
-	// On accepte NFS
-	system("iptables -A EXAM -p tcp -d $nfs_server --dport 111 -j ACCEPT");
-	system("iptables -A EXAM -p tcp -d $nfs_server --dport 2049 -j ACCEPT");
-	system("iptables -A EXAM -p udp -d $nfs_server --dport 111 -j ACCEPT");
-	system("iptables -A EXAM -p udp -d $nfs_server --dport 2049 -j ACCEPT");
-	// On accepte LDAP
-	system("iptables -A EXAM -p tcp -d $ldap_server --dport 636 -j ACCEPT");
-	system("iptables -A EXAM -p tcp -d $ldap_server --dport 3269 -j ACCEPT");
-	system("iptables -A EXAM -p udp -d $ldap_server --dport 636 -j ACCEPT");
-	system("iptables -A EXAM -p udp -d $ldap_server --dport 3269 -j ACCEPT");
-	// On accepte le port spécial
-	system("iptables -A EXAM -p tcp -d $net_server --dport 1337 -j ACCEPT");
-	system("iptables -A EXAM -p udp -d $net_server --dport 1337 -j ACCEPT");
-    }
-    // Il n'y a personne et EXAM existe
-    if (count($packet["users"]) == 0 && $EXAM)
-	system("iptables -F EXAM && iptables -X EXAM");
     
     // On parcoure les utilisateurs afin de trouver ceux en mode exam
     foreach ($packet["users"] as $usr)
     {
         $usr = explode(".", $usr);
-	// Leur compte est forcement prenom.nom.exam
+        
+        if (kill_unauthorized_sessions($usr, $exam_stats, $packet["users"]))
+            continue;
+
+	    // Leur compte est forcement prenom.nom.exam
         if (count($usr) == 3 && substr($usr[2], 0, 4) == "exam")
-	{
-	    $usr = $usr[0].$usr[1].".exam";
-	    // On regarde si l'utilisateur est déjà dans la liste pour rejet
-	    $out = shell_exec("iptables -L EXAM | grep $usr");
-	    if (strstr($out, $usr) === false)
 	    {
-		// Ce n'est pas le cas, on doit donc l'ajouter
-		if (!(system("iptables -A EXAM -m owner --uid-owner $usr -p all -j REJECT") === 0))
-		    // Si tout ne s'est pas bien passé, on déconnecte l'utilisateur
-		    system("skill -kill -u $usr");
-	    }
-	}
+            $usr = shell_exec("id -u ".$usr[0].$usr[1]."exam");
+            // On regarde si l'utilisateur est déjà dans la liste pour rejet
+            $out = shell_exec("nft list ruleset | grep $usr");
+            if (strlen($out) == 0 || str_contains($out, $usr) === false)
+            {
+            // Ce n'est pas le cas, on doit donc l'ajouter
+            system("nft add chain inet filter output {type filter hook output priority filter \; policy accept \; }");
+            system("nft add rule inet filter output meta squid $usr ip daddr $ip_nfs tcp dport 111 accept");
+            system("nft add rule inet filter output meta squid $usr ip daddr $ip_nfs tcp dport 2049 accept");
+            system("nft add rule inet filter output meta squid $usr ip daddr $ip_nfs udp dport 111 accept");
+            system("nft add rule inet filter output meta squid $usr ip daddr $ip_nfs udp dport 2049 accept");
+
+            system("nft add rule inet filter output meta squid $usr ip daddr $ip_ldap tcp dport 636 accept");
+            system("nft add rule inet filter output meta squid $usr ip daddr $ip_ldap tcp dport 3269 accept");
+            system("nft add rule inet filter output meta squid $usr ip daddr $ip_ldap udp dport 636 accept");
+            system("nft add rule inet filter output meta squid $usr ip daddr $ip_ldap udp dport 3269 accept");
+
+            system("nft add rule inet filter output meta squid $usr ip daddr $net_server tcp dport 1337 accept");
+            system("nft add rule inet filter output meta squid $usr ip daddr $net_server tcp dport 1337 accept");
+            
+            if (!(system("nft add rule filter output meta squid $usr reject") === 0))
+                system("pkill -u $usr");
+            }
+        }
+        $packet["date"] = trim(date("d/m/Y H:i:s", time()));
+        $packet["lock"] = file_exists("/tmp/block");
+        SendData($nfs_server, $packet);
+        
+        system("sleep 5.0");
     }
-    $packet["date"] = trim(date("d/m/Y H:i:s", time()));
-    $packet["lock"] = file_exists("/tmp/block");
-    SendData($nfs_server, $packet);
-    system("sleep 5.0");
 }
 while (1);
 exit(0);

--- a/wsidle
+++ b/wsidle
@@ -49,36 +49,80 @@ function kill_user(int $target_id, string $target_name, array $kill_area)
     return(true);
 }
 
-function kill_unauthorized_sessions(array $user, array $exam_stats, array $user_pool)
+function kill_unauthorized_sessions(array $user,
+				    array $exam_stats,
+				    array $user_pool,
+				    string $mode_connexion,
+				    array $room,
+				    string $nfs_server)
 {
     $has_killed_user = false;
     $username = $user[0].$user[1];
 
     if (count($user) == 3 && substr($user[2], 0, 4) == "exam")
-    {
-        $mode_connexion = explode(";", $user[2])[1];
-        
+    {        
         $exam_username = $username."exam";
         $user = shell_exec("id -u ".$exam_username);
 
         // On tue les sessions exam hors examens
         // Par contre ça va shutdown les sessions juste après le ramassage de Infosphere_hand mdr
-        if (!in_array($username, $exam_stats["users"]))
-            $has_killed_user = kill_user($user, $exam_username, $user_pool);
+	
+	if (!isset($exam_stats["users"][$username]))
+	    {
+		$has_killed_user = kill_user($user, $exam_username, $user_pool);
+		SendData($nfs_server, ["command" => "addcustomlog",
+				       "log" => "$exam_username has been killed, because ".
+					      "there is no exam for now !"]);
+	    }
+	else if ($exam_stats["users"][$username] != $room["name"])
+	    {
+		$has_killed_user = kill_user($user, $exam_username, $user_pool);
+		SendData($nfs_server, ["command" => "addcustomlog",
+				       "log" => "$exam_username has been killed, because ".
+					      "$exam_username is not in the right room"]);
+	    }
 
         // On tue les sessions exam qui ne sont pas en présentiels
         if (strncmp($mode_connexion, "tty", 3) != 0)
-            $has_killed_user = kill_user($user, $exam_username, $user_pool);
+	    {
+		$has_killed_user = kill_user($user, $exam_username, $user_pool);
+		SendData($nfs_server, ["command" => "addcustomlog",
+				       "log" => "$exam_username has been killed, because ".
+					      "exam cannot be in remote session"]);
+	    }
 
         // On tue les sessions exam en double, 
         // Normalement il y le Xauthority qui n'est pas en lien symbolique
         // On regarde s'il l'utilisateur est déjà connecté et s'il ne l'est pas ailleurs
-        if (in_array($exam_username, $exam_stats["connected"]) && $exam_stats["connected"][$exam_username] != refresh_ip())
+        if (isset($exam_stats["connected"][$exam_username])
+	    && $exam_stats["connected"][$exam_username] != refresh_ip())
+	{
             $has_killed_user = kill_user($user, $exam_username, $user_pool);
+	    SendData($nfs_server, ["command" => "addcustomlog",
+				   "log" => "$exam_username has been killed because".
+					  " $exam_username is already connected somewhere else !"]);
+	}
+    } // On tue toutes les sessions non exam dans une salle d'examen
+    else if ($room["exam_only"])
+    {
+	$has_killed_user = kill_user(shell_exec("id -u ".$username), $username, $user_pool);
+	SendData($nfs_server, ["command" => "addcustomlog",
+			       "log" => "$username has been killed because it's an exam only room"]);
     } // On tue les sessions non exam d'utilisateur en exam
     else if (in_array($username, $exam_stats["users"]))
+    {
         $has_killed_user = kill_user(shell_exec("id -u ".$username), $username, $user_pool);
+	SendData($nfs_server, ["command" => "addcustomlog",
+			     "log" => "$username has been killed because $username must be in exam"]);
     return $has_killed_user;
+}
+
+function get_room(string $computer_name)
+{
+    $ret = json_decode(SendData($nfs_server, ["command" => "getcomputerroom", "name" => $packet["name"]]));
+    if ($ret["result"] == "ok")
+	return $ret["content"];
+    return "";
 }
 
 if ($argc < 2 || $argv[1] == "")
@@ -105,12 +149,14 @@ $packet["type"] = (substr(shell_exec("uname -m"), 0, 6) == "x86_64") ? 0 : 3; //
 
 $EXAM = false;
 
-
+// Récupération de la room
+$room_info = ["name" => get_room($packet["name"]), "exam_only" => false];
 
 do
 {
     // Récupération des élèves en examens
     $exam_stats = json_decode(SendData($nfs_server, ["command" => "getexamstudents"])["content"]);
+    
     $packet["ip"] = refresh_ip();
     $packet["users"] = explode("\n", trim(shell_exec("who | cut -d ' ' -f 1,2 | tr ' ' ';' | sort | uniq")));
     
@@ -118,39 +164,51 @@ do
     foreach ($packet["users"] as $usr)
     {
         $usr = explode(".", $usr);
+	$mode_connexion = explode(";", end($user))[1];
         
-        if (kill_unauthorized_sessions($usr, $exam_stats, $packet["users"]))
+        if (kill_unauthorized_sessions($usr, $exam_stats, $packet["users"], $mode_connexion, $room_info))
             continue;
 
 	    // Leur compte est forcement prenom.nom.exam
         if (count($usr) == 3 && substr($usr[2], 0, 4) == "exam")
-	    {
+	{	    
             $usr = shell_exec("id -u ".$usr[0].$usr[1]."exam");
             // On regarde si l'utilisateur est déjà dans la liste pour rejet
             $out = shell_exec("nft list ruleset | grep $usr");
             if (strlen($out) == 0 || str_contains($out, $usr) === false)
             {
             // Ce n'est pas le cas, on doit donc l'ajouter
-            system("nft add chain inet filter output {type filter hook output priority filter \; policy accept \; }");
-            system("nft add rule inet filter output meta squid $usr ip daddr $ip_nfs tcp dport 111 accept");
-            system("nft add rule inet filter output meta squid $usr ip daddr $ip_nfs tcp dport 2049 accept");
-            system("nft add rule inet filter output meta squid $usr ip daddr $ip_nfs udp dport 111 accept");
-            system("nft add rule inet filter output meta squid $usr ip daddr $ip_nfs udp dport 2049 accept");
+		system("nft add chain inet filter output {type filter hook output ".
+		       "priority filter \; policy accept \; }");
+		system("nft add rule inet filter output meta squid $usr ".
+		       "ip daddr $ip_nfs tcp dport 111 accept");
+		system("nft add rule inet filter output meta squid $usr ".
+		       "ip daddr $ip_nfs tcp dport 2049 accept");
+		system("nft add rule inet filter output meta squid $usr ".
+		       "ip daddr $ip_nfs udp dport 111 accept");
+		system("nft add rule inet filter output meta squid $usr ".
+		       "ip daddr $ip_nfs udp dport 2049 accept");
 
-            system("nft add rule inet filter output meta squid $usr ip daddr $ip_ldap tcp dport 636 accept");
-            system("nft add rule inet filter output meta squid $usr ip daddr $ip_ldap tcp dport 3269 accept");
-            system("nft add rule inet filter output meta squid $usr ip daddr $ip_ldap udp dport 636 accept");
-            system("nft add rule inet filter output meta squid $usr ip daddr $ip_ldap udp dport 3269 accept");
+		system("nft add rule inet filter output meta squid $usr ".
+		       "ip daddr $ip_ldap tcp dport 636 accept");
+		system("nft add rule inet filter output meta squid $usr ".
+		       "ip daddr $ip_ldap tcp dport 3269 accept");
+		system("nft add rule inet filter output meta squid $usr ".
+		       "ip daddr $ip_ldap udp dport 636 accept");
+		system("nft add rule inet filter output meta squid $usr ".
+		       "ip daddr $ip_ldap udp dport 3269 accept");
 
-            system("nft add rule inet filter output meta squid $usr ip daddr $net_server tcp dport 1337 accept");
-            system("nft add rule inet filter output meta squid $usr ip daddr $net_server tcp dport 1337 accept");
+		system("nft add rule inet filter output meta squid $usr ".
+		       "ip daddr $net_server tcp dport 1337 accept");
+		system("nft add rule inet filter output meta squid $usr ".
+		       "ip daddr $net_server tcp dport 1337 accept");
             
             if (!(system("nft add rule filter output meta squid $usr reject") === 0))
                 system("pkill -u $usr");
             }
         }
         $packet["date"] = trim(date("d/m/Y H:i:s", time()));
-        $packet["lock"] = file_exists("/tmp/block");
+        $packet["lock"] = file_exists("/tmp/block") && strncmp($mode_connexion, "tty", 3) == 0;
         SendData($nfs_server, $packet);
         
         system("sleep 5.0");

--- a/wsidle
+++ b/wsidle
@@ -170,9 +170,9 @@ do
 	    continue;
 	$usr_part = explode(";", end($usr));
 	$usr[count($usr) - 1] = $usr_part[0];
-	$mode_connexion = $user_part[1];
+	$mode_connexion = $usr_part[1];
         
-        if (kill_unauthorized_sessions($usr, $exam_stats, $packet["users"], $mode_connexion, $room_info))
+        if (kill_unauthorized_sessions($usr, $exam_stats, $packet["users"], $mode_connexion, $room_info, $nfs_server))
             continue;
 
 	    // Leur compte est forcement prenom.nom.exam

--- a/wsidle
+++ b/wsidle
@@ -224,8 +224,8 @@ do
         $packet["lock"] = file_exists("/tmp/block") && strncmp($mode_connexion, "tty", 3) == 0;
         SendData($nfs_server, $packet);
         
-        system("sleep 5.0");
     }
+    system("sleep 5.0");
 }
 while (1);
 exit(0);

--- a/wsidle
+++ b/wsidle
@@ -128,6 +128,10 @@ function get_room(string $computer_name,
     return "";
 }
 
+// Reset nftables
+
+system("sudo nft flush ruleset; nft add table inet filter");
+
 if ($argc < 2 || $argv[1] == "")
     $argv[1] = "nfs.efrits.fr";
 if ($argc < 3 || $argv[2] == "")

--- a/wsidle
+++ b/wsidle
@@ -59,7 +59,8 @@ function kill_user(int $target_id,
 	system("pkill -u -9 $target_id");
 	$killer_manager["killed_user"][$target_name] = $killer_manager["time"];
     }
-    unset($kill_area[$target_name]);
+    if (isset($kill_area[$target_name]))
+	unset($kill_area[$target_name]);
     return(true);
 }
 
@@ -118,12 +119,12 @@ function kill_unauthorized_sessions(array $user,
 					  " $exam_username is already connected somewhere else !"]);
 	}
     } // On tue toutes les sessions non exam présentiel dans une salle d'examen
-    else if ($room["exam_only"] && strncmp($mode_connexion, "tty", 3) == 0)
+/*    else if ($room["exam_only"] && strncmp($mode_connexion, "tty", 3) == 0)
     {
 	$has_killed_user = kill_user(shell_exec("id -u ".$username), $username, $user_pool, $killer_manager);
 	SendData($nfs_server, ["command" => "addcustomlog",
 			       "log" => "$username has been killed because it's an exam only room"]);
-    } // On tue les sessions non exam d'utilisateur en exam
+    } */// On tue les sessions non exam d'utilisateur en exam
     else if (isset($exam_stats["users"][$username]))
     {
         $has_killed_user = kill_user(shell_exec("id -u ".$username), $username, $user_pool, $killer_manager);

--- a/wsidle
+++ b/wsidle
@@ -224,7 +224,7 @@ do
 		system("nft add rule inet filter output meta skuid $usr ".
 		       "ip daddr $net_server tcp dport 1337 accept");
             
-            if (!(system("nft add rule inet filter output meta skuid $usr reject") === 0))
+            if (system("nft add rule inet filter output meta skuid $usr reject") === false)
                 system("pkill -u $usr");
             }
         }

--- a/wsidle
+++ b/wsidle
@@ -138,6 +138,7 @@ if ($argc < 5 || $argv[4] == "")
     $argv[4] = "192.168.200.1";
 
 $nfs_server = $argv[1];
+$ip_nfs = $argv[2];
 $ldap_server = $argv[3];
 $net_server = $argv[4];
 

--- a/wsidle
+++ b/wsidle
@@ -52,15 +52,11 @@ function kill_user(int $target_id,
 	$killer_manager["killed_user"][$target_name] != ($killer_manager["time"] - 1))
     {
 	system("pkill -u $target_id");
-	$killer_manager["killed_user"][$target_name] = $killer_manager["time"];
     }
     else
-    {
 	system("pkill -u -9 $target_id");
-	$killer_manager["killed_user"][$target_name] = $killer_manager["time"];
-    }
-    if (isset($kill_area[$target_name]))
-	unset($kill_area[$target_name]);
+    $killer_manager["killed_user"][$target_name] = $killer_manager["time"];
+    unset($kill_area[$target_name]);
     return(true);
 }
 
@@ -241,17 +237,18 @@ do
 		       "ip daddr $net_server tcp dport 1337 accept");
             
             if (system("nft add rule inet filter output meta skuid $usr reject") === false)
-                system("pkill -u $usr");
+		kill_user(shell_exec("id -u ".$usr), $usr, $packet["users"], $killer_manager);
             }
         }
-        $packet["date"] = trim(date("d/m/Y H:i:s", time()));
-        $packet["lock"] = file_exists("/tmp/block") && strncmp($mode_connexion, "tty", 3) == 0;
-        SendData($nfs_server, $packet);
-        
     }
     $killer_manager["time"] += 1;
     if ($killer_manager["time"] == 1000000)
 	$killer_manager["time"] = 0;
+
+    $packet["date"] = trim(date("d/m/Y H:i:s", time()));
+    $packet["lock"] = file_exists("/tmp/block") && strncmp($mode_connexion, "tty", 3) == 0;
+    SendData($nfs_server, $packet);
+
     system("sleep 5.0");
 }
 while (1);


### PR DESCRIPTION
WorkSpy 2.0 terminé.
Coupe Internet aux élèves en exam. 
Peut permettre de monopoliser une salle pour un examen en déconnectant tous les utilisateurs qui ne sont pas en examen dans la salle.
Déconnecte les utilisateurs en examen à la fin de l'examen.
Ne bloque pas les connexions à distance.